### PR TITLE
chore(security): fix CVEs (2026-05-18)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6222,9 +6222,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
-      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/diff": {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "devDependencies": {
     "@nuxtjs/apollo": "^5.0.0-alpha.16",
     "@types/node": "^22.19.17"
+  },
+  "overrides": {
+    "devalue": "^5.8.1"
   }
 }


### PR DESCRIPTION
## Security fix — 2026-05-18

| Severity | Package | From | To | CVE |
|----------|---------|------|----|-----|
| high | devalue | 5.1.1 | 5.8.1 | DoS / prototype pollution |

Fixed via `npm overrides` in package.json.